### PR TITLE
Fix: convert_to_metrics_dict no longer accepts a third argument

### DIFF
--- a/keras_tuner_cv/inner_cv.py
+++ b/keras_tuner_cv/inner_cv.py
@@ -76,7 +76,7 @@ def inner_cv(
                     )
                 else:
                     metrics = tuner_utils.convert_to_metrics_dict(
-                        results, self.oracle.objective, "Tuner.run_trial()"
+                        results, self.oracle.objective
                     )
                     metrics.update(get_metrics_std_dict(results))
                     self.oracle.update_trial(


### PR DESCRIPTION
keras-tuner 1.1.3 no longer accepts a third positional argument to `utils.convert_to_metrics_dict`:

```
Traceback (most recent call last):
  File "search.py", line 182, in <module>
    main(args)
  File "search.py", line 147, in main
    parameter_tuner.search(X_cv_t, y_cv, epochs=10)
  File "venv\lib\site-packages\keras_tuner_cv\inner_cv.py", line 78, in search
    metrics = tuner_utils.convert_to_metrics_dict(
TypeError: convert_to_metrics_dict() takes 2 positional arguments but 3 were given
```

This patch omits the third argument, which does not seem to affect the cross-validation.