### PR TITLE
Added preprocessor and eval_batch_size key-word parameters to the inner_cv; added support of multi-inputs models; changed README and example/inner_cv

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Here is the list of implemented methodologies and how to use them!
 ### Outer Cross Validation
 
 ```python
-from keras_tuner_cv.outer_cv import OuterCV
+from keras_tuner_cv import OuterCV
 
 from keras_tuner.tuners import RandomSearch
 
@@ -33,18 +33,20 @@ outer_cv = OuterCV(
 )
 ```
 ### Inner Cross Validation
+
 ```python
-from keras_tuner_cv.outer_cv import OuterCV
+import keras.layers
+from keras_tuner_cv import inner_cv
 
 from keras_tuner.tuners import RandomSearch
 
 from sklearn.model_selection import KFold
 
 cv = KFold(n_splits=5, random_state=12345, shuffle=True),
-    
+
 # You can use any class extending:
 # keras_tuner.engine.tuner.Tuner, e.g. RandomSearch
-outer_cv = inner_cv(RandomSearch)(
+inner_cv = inner_cv(RandomSearch)(
     hypermodel,
     # You can use any class extendind:
     # sklearn.model_selection.cros.BaseCrossValidator
@@ -62,6 +64,18 @@ outer_cv = inner_cv(RandomSearch)(
     # scores.
     restore_best=True,
     # Tuner named parameters except hypermodel
+    preprocessor=None,
+    # Can ba one of:
+    #    - keras.layers.TextVectorization
+    #    - keras.layers.Normalization
+    #    - keras.layers.StringLookup
+    #    - keras.layers.IntegerLookup
+    #    - keras.layers.Discretization
+    # or any instance of a classes from sklearn.preprocessing 
+    # in which the fit and transform methods are implemented.
+    # if model has multi input preprocessor must be list of preprocessors
+    eval_batch_size=None
+    # batch size that will be used to validate the model on the test fold
     ...
 )
 ```

--- a/examples/inner_cv.py
+++ b/examples/inner_cv.py
@@ -37,8 +37,8 @@ def build_model(hp):
 
 
 tuner = inner_cv(RandomSearch)(
-    KFold(n_splits=5, random_state=12345, shuffle=True),
     build_model,
+    KFold(n_splits=5, random_state=12345, shuffle=True),
     save_output=True,
     save_history=True,
     objective=Objective("val_accuracy", direction="max"),

--- a/examples/inner_cv.py
+++ b/examples/inner_cv.py
@@ -53,8 +53,8 @@ tuner.search(
     x_train,
     y_train,
     validation_split=0.2,
-    batch_size="full-batch",
-    validation_batch_size="full-batch",
+    batch_size=32,
+    validation_batch_size=32,
     epochs=2,
     verbose=True,
 )

--- a/examples/inner_cv.py
+++ b/examples/inner_cv.py
@@ -1,9 +1,10 @@
-from keras_tuner_cv.inner_cv import inner_cv
+from keras_tuner_cv import inner_cv
 from keras_tuner_cv.utils import pd_inner_cv_get_result
 
 from sklearn.model_selection import KFold
 from keras_tuner.tuners import RandomSearch
 from keras_tuner import Objective
+from keras.layers import Normalization
 
 
 # Test environment
@@ -14,8 +15,6 @@ tf.get_logger().setLevel("INFO")
 mnist = tf.keras.datasets.mnist
 
 (x_train, y_train), (x_test, y_test) = mnist.load_data()
-x_train, x_test = x_train / 255.0, x_test / 255.0
-
 
 def build_model(hp):
     model = tf.keras.models.Sequential(
@@ -45,8 +44,9 @@ tuner = inner_cv(RandomSearch)(
     project_name="0",
     directory="./out/inner-cv/",
     seed=12345,
-    overwrite=False,
+    overwrite=True,
     max_trials=2,
+    preprocessor=Normalization()
 )
 
 tuner.search(

--- a/examples/outer_cv.py
+++ b/examples/outer_cv.py
@@ -1,4 +1,4 @@
-from keras_tuner_cv.outer_cv import OuterCV
+from keras_tuner_cv import OuterCV
 
 from sklearn.model_selection import KFold
 from keras_tuner.tuners import RandomSearch

--- a/keras_tuner_cv/__init__.py
+++ b/keras_tuner_cv/__init__.py
@@ -1,0 +1,2 @@
+from keras_tuner_cv.inner_cv import inner_cv
+from keras_tuner_cv.outer_cv import OuterCV

--- a/keras_tuner_cv/inner_cv.py
+++ b/keras_tuner_cv/inner_cv.py
@@ -235,6 +235,13 @@ def inner_cv(
                         )
 
                     # Evaluate train performance on best epoch
+                    tf.get_logger().info(
+                        "\n" + "-" * 40 + "\n"
+                                          "Evaluate train performance on best epoch"
+                        + "\n"
+                        + "-" * 40
+                        + "\n"
+                    )
                     obj_value = model.evaluate(
                         x_train,
                         y_train,
@@ -244,6 +251,13 @@ def inner_cv(
                     )
 
                     # Evaluate validation performance on best epoch
+                    tf.get_logger().info(
+                        "\n" + "-" * 45 + "\n"
+                                          "Evaluate validation performance on best epoch"
+                        + "\n"
+                        + "-" * 45
+                        + "\n"
+                    )
                     val_res = model.evaluate(
                         x_test,
                         y_test,

--- a/keras_tuner_cv/inner_cv.py
+++ b/keras_tuner_cv/inner_cv.py
@@ -188,11 +188,8 @@ def inner_cv(
                     callbacks.append(
                         tuner_utils.SaveBestEpoch(
                             objective=self.oracle.objective,
-                            filepath=self._get_checkpoint_fname(trial.trial_id)
-                                     + "_"
-                                     + str(execution)
-                                     + "_"
-                                     + str(split),
+                            filepath=self._get_checkpoint_fname(trial.trial_id) + "_" + str(execution) + "_" + str(
+                                split),
                         )
                     )
                     copied_kwargs["callbacks"] = callbacks
@@ -206,12 +203,8 @@ def inner_cv(
                         # Load the best epoch according to objective function
                         model = self._try_build(trial.hyperparameters)
                         model.load_weights(
-                            self._get_checkpoint_fname(trial.trial_id)
-                            + "_"
-                            + str(execution)
-                            + "_"
-                            + str(split)
-                        ).expect_partial()
+                            self._get_checkpoint_fname(trial.trial_id) + "_" + str(execution) + "_"
+                            + str(split)).expect_partial()
 
                     trial_path = self.get_trial_dir(trial.trial_id)
                     # Save the history if requested
@@ -241,10 +234,10 @@ def inner_cv(
 
                     # Evaluate train performance on best epoch
                     tf.get_logger().info(
-                        "\n" + "-" * 40 + "\n"
+                        "\n" + "-" * 45 + "\n"
                                           "Evaluate train performance on best epoch"
                         + "\n"
-                        + "-" * 40
+                        + "-" * 45
                         + "\n"
                     )
                     obj_value = model.evaluate(
@@ -281,7 +274,8 @@ def inner_cv(
             # scores across the folds.
             return histories
 
-        def __get_filename_path(self, trial_path, name, ext, execution, split):
+        @staticmethod
+        def __get_filename_path(trial_path, name, ext, execution, split):
             return os.path.join(
                 trial_path,
                 name + "_" + str(execution) + "_" + str(split) + ext,
@@ -339,7 +333,8 @@ def inner_cv(
             ) as fp:
                 np.save(fp, y)
 
-        def __save_history(self, history, filename):
+        @staticmethod
+        def __save_history(history, filename):
             with open(
                     filename,
                     "w",

--- a/keras_tuner_cv/inner_cv.py
+++ b/keras_tuner_cv/inner_cv.py
@@ -34,6 +34,7 @@ def inner_cv(
                 save_output=False,
                 restore_best=True,
                 preprocessor=None,
+                eval_batch_size=None,
                 **kwargs,
         ):
             """TunerCV constructor.
@@ -48,6 +49,7 @@ def inner_cv(
             self._restore_best = restore_best
             self._verbose = True
             self._preprocessor = preprocessor
+            self._eval_batch_size = eval_batch_size
 
         def search(self, *fit_args, **fit_kwargs):
             if "verbose" in fit_kwargs:
@@ -245,7 +247,7 @@ def inner_cv(
                     obj_value = model.evaluate(
                         x_train,
                         y_train,
-                        batch_size=len(x_train),
+                        batch_size=self._eval_batch_size,
                         return_dict=True,
                         verbose=self._verbose,
                     )
@@ -261,7 +263,7 @@ def inner_cv(
                     val_res = model.evaluate(
                         x_test,
                         y_test,
-                        batch_size=len(x_test),
+                        batch_size=self._eval_batch_size,
                         return_dict=True,
                         verbose=self._display.verbose,
                     )

--- a/keras_tuner_cv/inner_cv.py
+++ b/keras_tuner_cv/inner_cv.py
@@ -124,6 +124,7 @@ def inner_cv(
                 self._multiple_input = True
                 n_sample = len(X[0])
             else:
+                self._multiple_input = False
                 n_sample = len(X)
             # Run the training process multiple times.
             histories = []

--- a/keras_tuner_cv/outer_cv.py
+++ b/keras_tuner_cv/outer_cv.py
@@ -14,12 +14,12 @@ from multiprocessing import Process
 
 class OuterCV:
     def __init__(
-        self,
-        outer_cv: BaseCrossValidator,
-        tuner_class,
-        *args,
-        multiprocess=False,
-        **kwargs,
+            self,
+            outer_cv: BaseCrossValidator,
+            tuner_class,
+            *args,
+            multiprocess=False,
+            **kwargs,
     ):
         """OuterCV constructor.
 
@@ -65,7 +65,7 @@ class OuterCV:
             if self._verbose:
                 tf.get_logger().info(
                     "\n" + "-" * 30 + "\n"
-                    f"[Search] Outer Cross-Validation {split + 1}/{self._outer_cv.get_n_splits()}"
+                                      f"[Search] Outer Cross-Validation {split + 1}/{self._outer_cv.get_n_splits()}"
                     + "\n"
                     + "-" * 30
                     + "\n"
@@ -103,7 +103,7 @@ class OuterCV:
             if self._verbose:
                 tf.get_logger().info(
                     "\n" + "-" * 30 + "\n"
-                    f"[Evaluate] Outer Cross-Validation {split + 1}/{self._outer_cv.get_n_splits()}"
+                                      f"[Evaluate] Outer Cross-Validation {split + 1}/{self._outer_cv.get_n_splits()}"
                     + "\n"
                     + "-" * 30
                     + "\n"
@@ -174,7 +174,8 @@ class OuterCV:
             results.append(self._tuners[i].get_best_hyperparameters(num_trials=1)[0])
         return results
 
-    def _evaluate(self, model, x, y, prefix=""):
+    @staticmethod
+    def _evaluate(model, x, y, prefix=""):
         evaluation = model.evaluate(x, y, batch_size=len(x), return_dict=True)
         return {prefix + str(key): val for key, val in evaluation.items()}
 
@@ -191,8 +192,8 @@ class OuterCV:
             )
             copied_kwargs["validation_data"] = (x_val, y_val)
             if (
-                "validation_batch_size" in kwargs
-                and kwargs.get("validation_batch_size") == "full-batch"
+                    "validation_batch_size" in kwargs
+                    and kwargs.get("validation_batch_size") == "full-batch"
             ):
                 copied_kwargs["validation_batch_size"] = len(x_val)
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
 
 setup(
     name="keras_tuner_cv",
-    version="1.2.1",
+    version="1.3.0",
     description="Extension for keras tuner that adds a set of classes to implement cross validation techniques.",
     license="GPL v3",
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
 
 setup(
     name="keras_tuner_cv",
-    version="1.0.3",
+    version="1.2.0",
     description="Extension for keras tuner that adds a set of classes to implement cross validation techniques.",
     license="GPL v3",
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
 
 setup(
     name="keras_tuner_cv",
-    version="1.4.1",
+    version="1.5.1",
     description="Extension for keras tuner that adds a set of classes to implement cross validation techniques.",
     license="GPL v3",
     long_description=long_description,
@@ -17,5 +17,7 @@ setup(
     url="https://github.com/giuseppegrieco/keras-tuner-cv",
     packages=find_packages(),
     include_package_data=True,
-    install_requires=["keras_tuner"],
+    install_requires=[
+        "keras_tuner <= 1.1.3",
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
 
 setup(
     name="keras_tuner_cv",
-    version="1.3.0",
+    version="1.3.1",
     description="Extension for keras tuner that adds a set of classes to implement cross validation techniques.",
     license="GPL v3",
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
 
 setup(
     name="keras_tuner_cv",
-    version="1.2.0",
+    version="1.2.1",
     description="Extension for keras tuner that adds a set of classes to implement cross validation techniques.",
     license="GPL v3",
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
 
 setup(
     name="keras_tuner_cv",
-    version="1.3.1",
+    version="1.4.1",
     description="Extension for keras tuner that adds a set of classes to implement cross validation techniques.",
     license="GPL v3",
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as f:
 
 setup(
     name="keras_tuner_cv",
-    version="1.5.1",
+    version="1.5.2",
     description="Extension for keras tuner that adds a set of classes to implement cross validation techniques.",
     license="GPL v3",
     long_description=long_description,
@@ -19,5 +19,6 @@ setup(
     include_package_data=True,
     install_requires=[
         "keras_tuner <= 1.1.3",
+        "scikit-learn",
     ],
 )


### PR DESCRIPTION
- Added the ability to use  `preprocessors` of data such as `keras.layers.Normalization` or `MinMaxScaler` from `sklearn.preprocessing` for data preprocessing at each split into training and test samples during cross-validation. This allows the test to be closer to the actual use of the model. 
- Support for cases where the model has multiple inputs.
- Added parameter `eval_batch_size` - allows you to control the size of the batch when validating the model on a test fold.
- Fixed typos in `README.md`.
-  Added a description of new parameters to the  `README.md`
- Added import of the `inner_cv` function and the `OuterCV` class to the `__init__.py`, which now allows you to do `from keras_tuner_cv import inner_cv` or `OuterCV` instead of `from keras_tuner_cv.inner_cv import inner_cv`
- The recently released version of [keras-tuner 1.2](https://pypi.org/project/keras-tuner/) has [incompatible](https://github.com/keras-team/keras-tuner/releases/tag/1.2.0) changes. Therefore, I decided to limit the tuner version to version 1.1.3 with which `keras-tuner-cv` works.
- Added `scikit-learn` to the install requires
